### PR TITLE
fix next-connect integration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,12 +42,12 @@ export default function withJoi(config?: Configuration): ValidationFunction {
         return onValidationError(req, res, validationError);
       }
 
-      if (undefined !== next) {
-        return next();
-      }
-
       if (undefined !== handler) {
         return handler(req, res);
+      }
+
+      if (undefined !== next) {
+        return next();
       }
 
       res.status(404).end();


### PR DESCRIPTION
Condition with next
```
if (undefined !== next) {
    return next();
}
```
always triggered before handler. When next-connect used this behavior always return 404 status.